### PR TITLE
Fix RAF delta guard to prevent game loop freeze

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,8 +406,19 @@ function resetWorld() {
   // ========================= [LOOP: RAF & ACCUMULATOR] =========================
   let last = performance.now(), acc = 0, fps=60, fa=0, fc=0, ft=0;
   function raf(now) {
-    let dt = (now - last)/1000; last = now; if (dt > 0.25) dt = 0.25;
-    acc += dt; while (acc >= DT) { updateFixed(DT); acc -= DT; }
+    let dt = (now - last) / 1000;
+    last = now;
+
+    if (!Number.isFinite(dt) || dt <= 0) {
+      dt = DT;
+    } else if (dt > 0.25) {
+      dt = 0.25;
+    }
+
+    acc += dt;
+    if (!Number.isFinite(acc) || acc < 0) acc = 0;
+
+    while (acc >= DT) { updateFixed(DT); acc -= DT; }
     render();
     fa += 1/(dt||1/60); fc++; ft += dt; if (ft >= 0.25) { fps = Math.round(fa/fc); fa=fc=ft=0; }
     requestAnimationFrame(raf);


### PR DESCRIPTION
## Summary
- guard the requestAnimationFrame loop against invalid or non-positive delta times
- reset the accumulator when it becomes non-finite before stepping the fixed timestep loop

## Testing
- Playwright script simulating gameplay to ensure the timer continues to tick and sudden death engages (`artifacts/test-results.txt`).

------
https://chatgpt.com/codex/tasks/task_b_68cccd3e7d6c8324b70ea69dedf28030